### PR TITLE
Fix bot settings view initialization crash

### DIFF
--- a/material_gui/views/bot_settings.py
+++ b/material_gui/views/bot_settings.py
@@ -61,6 +61,11 @@ class BotSettingsView(BaseView):
         self._flux_style_combo = QComboBox()
         self._sdxl_style_combo = QComboBox()
         self._qwen_style_combo = QComboBox()
+        self._variation_mode_combo = QComboBox()
+        self._display_pref_combo = QComboBox()
+        self._default_engine_combo = QComboBox()
+        self._default_engine_combo.addItems(["kontext", "qwen"])
+        self._llm_provider_combo = QComboBox()
 
         for combo in (
             self._model_combo,
@@ -125,14 +130,8 @@ class BotSettingsView(BaseView):
         self._qwen_edit_denoise_spin.setRange(0.0, 1.0)
         self._qwen_edit_denoise_spin.setSingleStep(0.01)
 
-        self._variation_mode_combo = QComboBox()
-        self._display_pref_combo = QComboBox()
-        self._default_engine_combo = QComboBox()
-        self._default_engine_combo.addItems(["kontext", "qwen"])
-
         self._remix_checkbox = QCheckBox("Enable Remix Mode for variation buttons")
         self._llm_checkbox = QCheckBox("Enable LLM Prompt Enhancer")
-        self._llm_provider_combo = QComboBox()
         self._llm_model_combo = QComboBox()
         self._llm_model_combo.setEditable(True)
         self._llm_model_combo.currentIndexChanged.connect(self._queue_save)  # pragma: no cover - Qt binding


### PR DESCRIPTION
## Summary
- instantiate the variation, display preference, default engine, and LLM provider combo boxes before connecting signals in the bot settings view to avoid attribute errors during startup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9ce3a9254832c86ad96a615348f3c