### PR TITLE
Fix updater defaults and handoff

### DIFF
--- a/config_editor_main.py
+++ b/config_editor_main.py
@@ -569,7 +569,8 @@ class ConfigEditor:
                         if hasattr(self, 'favorites_tab_manager'): self.favorites_tab_manager.populate_all_favorites_sub_tabs()
                 else: silent_showerror(f"{task_name_done} Failed", message_details, parent=self.master)
             elif worker_status_update.get("type") == "restart_required":
-                self._restart_application()
+                update_info = worker_status_update.get("update_info")
+                self._restart_application(update_info=update_info)
         except queue.Empty: pass
         except Exception: pass
         if self.master.winfo_exists(): self.master.after(100, self._process_gui_updates_loop)

--- a/editor_config_manager.py
+++ b/editor_config_manager.py
@@ -32,7 +32,7 @@ class EditorConfigManager:
             "ADMIN": {"USERNAME": "", "ID": ""},
             "ALLOWED_USERS": {},
             "LLM_ENHANCER": {"OPENAI_API_KEY": "", "GEMINI_API_KEY": "", "GROQ_API_KEY": ""},
-            "APP_SETTINGS": {"AUTO_UPDATE_ON_STARTUP": True}
+            "APP_SETTINGS": {"AUTO_UPDATE_ON_STARTUP": False}
         }
         self.settings_template_factory = lambda: {
              "selected_model": None, 

--- a/updater.py
+++ b/updater.py
@@ -18,18 +18,23 @@ def log(message):
 
 def main():
     log("Updater script started.")
-    if len(sys.argv) != 4:
-        log(f"FATAL: Incorrect number of arguments. Expected 3, got {len(sys.argv) - 1}")
+    if len(sys.argv) not in {4, 5}:
+        log(
+            f"FATAL: Incorrect number of arguments. Expected 3 or 4, got {len(sys.argv) - 1}"
+        )
         log(f"Arguments: {sys.argv}")
         return
 
     parent_pid = int(sys.argv[1])
     source_dir = sys.argv[2]
     dest_dir = sys.argv[3]
+    target_tag = sys.argv[4] if len(sys.argv) == 5 else None
 
     log(f"Parent PID: {parent_pid}")
     log(f"Source (temp) dir: {source_dir}")
     log(f"Destination (app) dir: {dest_dir}")
+    if target_tag:
+        log(f"Target release tag: {target_tag}")
 
     # 1. Wait for the main application to close
     try:


### PR DESCRIPTION
## Summary
- disable the configurator auto-update option by default and reconcile update state on startup
- integrate update state checks and version comparisons into the legacy Tk update workflow to prevent first-run loops
- allow updater.py to accept an optional release tag so GUI handoffs no longer abort on launch

## Testing
- pytest *(fails: ImportError: cannot import name 'QWEN_CHECKPOINT_LOADER_NODE' from 'prompt_templates')*

------
https://chatgpt.com/codex/tasks/task_e_68e28a937ecc832c8b462636db9f2e0e