### PR TITLE
Handle missing version_info import in config editor

### DIFF
--- a/config_editor_main.py
+++ b/config_editor_main.py
@@ -50,7 +50,17 @@ from editor_tab_bot_control import BotControlTab
 from editor_tab_admin_control import AdminControlTab
 from utils.update_state import UpdateState
 from utils.versioning import normalise_tag, is_remote_version_newer
-from version_info import APP_VERSION
+try:
+    from version_info import APP_VERSION
+except ModuleNotFoundError:
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    if current_dir not in sys.path:
+        sys.path.insert(0, current_dir)
+
+    try:
+        from version_info import APP_VERSION
+    except ModuleNotFoundError:
+        APP_VERSION = "unknown"
 
 class ConfigEditor:
     def __init__(self, master_tk_root):


### PR DESCRIPTION
## Summary
- add a fallback when importing `APP_VERSION` so the editor still starts if `version_info` is missing
- ensure the script inserts its directory into `sys.path` before retrying the import and default to `"unknown"` when unavailable

## Testing
- python -m py_compile config_editor_main.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ecc0c29c832ca562efa6d57fb496